### PR TITLE
Fixing paths in IDDSamples.html

### DIFF
--- a/IDDSamples.html
+++ b/IDDSamples.html
@@ -21,7 +21,7 @@
         }
 
         function pageLoad() {
-            document.getElementById("sampleHost").src = 'Samples/Axes and navigation.html';
+            document.getElementById("sampleHost").src = 'samples/Axes and navigation.html';
             $("#currenSample").text('Axes and Navigation');
             $("#axesNnav").addClass("selected");
         }
@@ -83,39 +83,39 @@
 <body onload="pageLoad()">
     <div class="menu">
         <div class="category" style="margin-top: 0px;">Basic Plot Samples</div>
-        <div id="axesNnav" class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Axes and navigation.html')">Axes and Navigation</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Titles.html')">Titles</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Custom plot.html')">Custom Plot</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Add and Remove plots using API.html')">Add/Remove Plot</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/AutoFitSample.html')">AutoFit modes and FitToView</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Nested charts.html')">Nested Charts</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/DOM elements in a plot.html')">DOM elements in a Plot</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/NestedChartAsDOMPlot.html')">Nested chart as DOM Plot</div>
+        <div id="axesNnav" class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Axes and navigation.html')">Axes and Navigation</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Titles.html')">Titles</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Custom plot.html')">Custom Plot</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Add and Remove plots using API.html')">Add/Remove Plot</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/AutoFitSample.html')">AutoFit modes and FitToView</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Nested charts.html')">Nested Charts</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/DOM elements in a plot.html')">DOM elements in a Plot</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/NestedChartAsDOMPlot.html')">Nested chart as DOM Plot</div>
         <div class="category">Polyline Plot Samples</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Draw a polyline in HTML.html')">Simple Polyline</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Dynamic polyline.html')">Dynamic Polyline</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Draw a polyline in HTML.html')">Simple Polyline</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Dynamic polyline.html')">Dynamic Polyline</div>
         <div class="category">Markers Plot Samples</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Markers.html')">Simple Markers</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Dynamic Markers.html')">Dynamic Markers</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Markers with custom series.html')">Markers with custom Color and Size series</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Bar chart.html')">Bar Chart</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Error bars.html')">Error Bars</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Markers.html')">Simple Markers</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Dynamic Markers.html')">Dynamic Markers</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Markers with custom series.html')">Markers with custom Color and Size series</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Bar chart.html')">Bar Chart</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Error bars.html')">Error Bars</div>
         <div class="category">Heatmap Plot Samples</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Heatmap.html')">Simple Heatmap Plot</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Dynamic Matrix Heatmap.html')">Dynamic Matrix Heatmap</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Dynamic Gradient Heatmap.html')">Dynamic Gradient Heatmap</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Heatmap.html')">Simple Heatmap Plot</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Dynamic Matrix Heatmap.html')">Dynamic Matrix Heatmap</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Dynamic Gradient Heatmap.html')">Dynamic Gradient Heatmap</div>
         <div class="category">Bing Map Samples</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/StandaloneBingMaps.html')">Bing Maps Plot</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Custom map layers.html')">Custom Map Layers</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Markers on a map.html')">Markers on a map</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/BingMapsHeatmapSample.html')">Heatmap on a map</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/StandaloneBingMaps.html')">Bing Maps Plot</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Custom map layers.html')">Custom Map Layers</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Markers on a map.html')">Markers on a map</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/BingMapsHeatmapSample.html')">Heatmap on a map</div>
         <div class="category">Misc Samples</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/LabelledAxisSample.html')">Labels on Axis</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/DepthGraphSample.html')">Inverted Vertical Axis</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Logarithmic transform.html')">Logarithmic transform</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Color palettes.html')">Color Palettes</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/LegendSample.html')">Legend Samples</div>
-        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'Samples/Bound plots.html')">Bound Plots</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/LabelledAxisSample.html')">Labels on Axis</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/DepthGraphSample.html')">Inverted Vertical Axis</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Logarithmic transform.html')">Logarithmic transform</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Color palettes.html')">Color Palettes</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/LegendSample.html')">Legend Samples</div>
+        <div class="href" onclick="onHoverA(arguments[0].currentTarget, 'samples/Bound plots.html')">Bound Plots</div>
     </div>
 
     <div style="position: absolute; left: 350px; top: 0px; width: 70%">


### PR DESCRIPTION
Source paths are case sensitive in Linux.
IDDSamples.html references separate samples with valid case insensitive paths but invalid case sensiitve.

That's why IDDSamples.html does not load sample when serving from local filesystem.

This pull request fixes the pathes. 