### PR TITLE
Dom elements tracking.

### DIFF
--- a/src/js/idd.base.js
+++ b/src/js/idd.base.js
@@ -113,14 +113,21 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             mutations.forEach(function(mutation) {
               var added=mutation.addedNodes, removed = mutation.removedNodes;
               if(added.length>0)
-                for(var i=0; i< added.length;i++) {
-                  var jqAdded = $(added[i]);
-                  if(jqAdded.attr("data-idd-plot") && !(jqAdded.hasClass("idd-plot-master")))
-                    plot.addChild(initializePlot(jqAdded,master));
-                  };
+                  for(var i=0; i< added.length;i++) {
+                      var jqAdded = $(added[i]);
+                      if(jqAdded.attr("data-idd-plot")) {
+                          jqAdded.removeClass("idd-plot-master").removeClass("idd-plot-dependant");
+                          plot.addChild(initializePlot(jqAdded,master));
+                      };
+                  }
               if(removed.length>0)
                 for(var i=0; i< removed.length;i++) {
-                  plot.removeChild(InteractiveDataDisplay.asPlot($(removed[i])));        
+                  var elem = removed[i];
+                  if(typeof elem.getAttribute === "function") {
+                    var plotAttr = elem.getAttribute("data-idd-plot");
+                    if(plotAttr != null)
+                      plot.removeChild(elem.plot);        
+                    }
                   }
             });
           });

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jasmine Spec Runner v2.3.4</title>
+
+  <link rel="shortcut icon" type="image/png" href="../ext/jasmine/images/jasmine_favicon.png">
+  <link rel="stylesheet" href="../ext/jasmine/lib/jasmine-core/jasmine.css">
+
+  <script src="../ext/jasmine/lib/jasmine-core/jasmine.js"></script>
+  <script src="../ext/jasmine/lib/jasmine-core/jasmine-html.js"></script>
+  <script src="../ext/jasmine/lib/jasmine-core/boot.js"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+  <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/3.1.2/rx.lite.min.js"></script>
+
+  <!-- include source files here... -->
+  <script src="../dist/idd.js"></script> 
+
+  <!-- include spec files here... -->
+  <script src="bingMapsAnimationTests.js"></script>
+  <script src="coordinateTransformTests.js"></script>
+  <script src="domPlotTests.js"></script>
+  <script src="navigationTests.js"></script>
+  <script src="paletteTests.js"></script>
+  <script src="plotTests.js"></script>
+  <script src="utilsTests.js"></script>
+</head>
+
+<body>
+</body>
+</html>

--- a/test/domPlotTests.js
+++ b/test/domPlotTests.js
@@ -7,10 +7,12 @@
 // https://github.com/pivotal/jasmine/wiki 
 
 describe('InteractiveDataDisplay.DOMPlot', function () {
-    var plot;
+    var plot,div;
 
+    var isPhantomJS = /PhantomJS/.test(window.navigator.userAgent);
+    
     beforeEach(function () {
-        var div = document.createElement("div");
+        div = document.createElement("div");
         div.setAttribute("data-idd-plot", "dom");
         div.setAttribute("data-idd-name", "dom");
         plot = InteractiveDataDisplay.asPlot($(div));
@@ -106,5 +108,38 @@ describe('InteractiveDataDisplay.DOMPlot', function () {
         expect(bb.width).toBe(1.4);
         expect(bb.height).toBe(2.8);
     });
+    
+    if (!isPhantomJS) {
+      it('should track added dom elements', function(done) {
+        plot.onChildrenChanged = function() {
+          expect(plot.children.length).toBe(1);          
+          expect(div.children.length).toBe(3);
+          done();
+        }
+        expect(plot.children.length).toBe(0);
+        $(div).append("<div></div>"); //element without idd-data-plot attribute must not be registered
+        $(div).append("<div data-idd-plot='polyline' class='idd-plot-master'></div>"); //element with idd-data-plot attribute AND idd-plot-master class must not be regestered (as already registered manually)
+        $(div).append("<div data-idd-plot='polyline'></div>"); //element with idd-data-plot attribute must be registered as plot
+      });
+      
+      it('should track removed dom elements', function(done) {
+        var polyline;
+        var element = document.createElement("div");
+        element.setAttribute("data-idd-plot","polyline");
+        plot.onChildrenChanged = function() {
+          expect(plot.children.length).toBe(1);          
+          expect(div.children.length).toBe(1);
+          plot.onChildrenChanged = function() {
+            expect(plot.children.length).toBe(0);
+            expect(div.children.length).toBe(0);
+            done();
+          };
+          $(element).remove();
+          
+        }
+        
+        polyline = $(div).append(element); //element with idd-data-plot attribute must be registered as plot
+      });
+    }
 });
 


### PR DESCRIPTION
1. Test "should remove existing DOM element" succeeded on PhanthomJS but failed on Firefox,Chrome. This pull request fixes it.
2. IDD now tracks the insertions of new DOM elements into existing plots and transforms them into new plots. It enables binding IDD to viewmodels through KnockoutJS or other MVVM frameworks (via propper DOM manipulation)
3. SpecRunner.html page now can run all the tests in the browser (invocation of this is not included in the grunt tasks)