### PR TITLE
Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - npm install grunt-cli -g

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "grunt-ts": "^5.2.0",
     "grunt-tsd": "^0.1.0",
     "grunt-wiredep": "^2.0.0"
+  },
+  "scripts": {
+	"test": "grunt default test --verbose"
   }
 }

--- a/test/plotTests.js
+++ b/test/plotTests.js
@@ -26,6 +26,10 @@ describe('InteractiveDataDisplay.Plot', function () {
     beforeEach(function () {
         plot = newPlot("master");
     });
+    
+    afterEach(function () {
+        plot.onChildrenChanged = function() { };
+    });
 
     it('should be properly initialized', function () {
         expect(plot.name).toBe("master");
@@ -55,8 +59,8 @@ describe('InteractiveDataDisplay.Plot', function () {
         var element = newPlotNoInitialization("line1", "polyline");
         var div = plot.host;
         plot.onChildrenChanged = function() {
-          // This should be true when polyline div is appended
-          expect(plot.children.length).toBe(1);          
+          // This should be true when polyline div is appended          
+          expect(plot.children.length).toBe(1);                    
           expect(div.children().length).toBe(1);
           
           plot.onChildrenChanged = function() {


### PR DESCRIPTION
This commit has all necessary configuration for enabling Travis CI builds.

Just go to travis-ci.org and enable builds for predioctionmachines/InteractiveDataDisplay.

This pull request does not contain build indicator on the readme.md, however it is still very useful e.g. travis CI builds pull requests, so you can see build&tests status before accepting pull requests.

It also fixed #16 