### PR TITLE
screen size check to avoid error in console (rendering before arrange)

### DIFF
--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -820,14 +820,16 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                 renderAll = true;
                 that.updateLayout(); // this eventually fires the frameRendered event
             } else {
-                that.isAnimationFrameRequested = false;
+                if (that.screenSize.height != undefined && that.screenSize.width != undefined) {
+                    that.isAnimationFrameRequested = false;
 
-                var screenSize = that.screenSize;
-                var plotRect = that.coordinateTransform.getPlotRect({ x: 0, y: 0, width: screenSize.width, height: screenSize.height }); // (x,y) is left/top            
-                // rectangle in the plot plane which is visible, (x,y) is left/bottom (i.e. less) of the rectangle
+                    var screenSize = that.screenSize;
+                    var plotRect = that.coordinateTransform.getPlotRect({ x: 0, y: 0, width: screenSize.width, height: screenSize.height }); // (x,y) is left/top            
+                    // rectangle in the plot plane which is visible, (x,y) is left/bottom (i.e. less) of the rectangle
 
-                updatePlotsOutputRec(renderAll, _master, plotRect, screenSize);  
-                that.fireFrameRendered();
+                    updatePlotsOutputRec(renderAll, _master, plotRect, screenSize);
+                    that.fireFrameRendered();
+                }
             }
             renderAll = false;          
 


### PR DESCRIPTION
Biology Tools in the Edge browser are getting an error from the IDD during application startup. Possible reason: plot rendering for some plots is called before arrange method.
Added screenSize check to make sure the error does not arise. The flag isAnimationFrameRequested is not set to false, ensuring the rendering is performed after initialization.

@sergey-berezin @dvoits please confirm