### PR TITLE
Scientific notation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,16 @@
+### 1.5.20 (January 15, 2019)
+
+New features:
+ - added support for data-idd-scientific-notation attribute on numeric axes. With this feature enabled ticks are represented in a form: m × 10ⁿ, where 1≤m≤9 for numbers(modulo): ≥10³ that divisible exactly by 10³, or <10⁻³ 
+
 ### 1.5.19 (December 27, 2018)
 
 New features:
  - Tooltip now shows the labels of label axis (in case of label axis depicts intervals)
  - Plot coordinates info can be suppressed in tooltip with `data-idd-suppress-tooltip-coords`
 
- ### 1.5.18 (December 21, 2018)
- - base64 data source is now suppoerted for specifing the data declaratively
+### 1.5.18 (December 21, 2018)
+ - base64 data source is now supported for specifying the data declaratively
  - Label axis data can be specified declaratively in the DOM before IDD plot initialization
 
 ### 1.5.17 (December 13, 2018)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-data-display",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "license": "Apache-2.0",
   "homepage": "https://github.com/predictionmachines/InteractiveDataDisplay/wiki",
   "description": "A JavaScript visualization library for dynamic data",

--- a/samples/NumericAxis.html
+++ b/samples/NumericAxis.html
@@ -27,7 +27,7 @@
         data-idd-navigation-enabled="true" data-idd-legend-enabled="true">
         <div id="grid1" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'
             data-idd-xaxis='bottom_axis1'></div>
-        <div id="bottom_axis1" data-idd-axis="numeric" data-idd-placement="bottom" style="position: relative;"></div>
+        <div id="bottom_axis1" data-idd-axis="numeric" data-idd-scientific-notation="true" data-idd-placement="bottom" style="position: relative;"></div>
     </div>
 </body>
 </html>

--- a/samples/NumericAxis.html
+++ b/samples/NumericAxis.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10; IE=Edge" />
+    <title>Numeric sample</title>
+    <link rel="stylesheet" type="text/css" href="../dist/idd.css" />
+    <link rel="stylesheet" type="text/css" href="../src/css/IDDTheme.css" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/3.1.2/rx.lite.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.4.0/svg.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script> 
+    <script src="../dist/idd.js"></script>
+
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var plot1 = InteractiveDataDisplay.asPlot($("#figure1"));
+        });
+    </script>
+</head>
+<body style="font-family: Segoe UI; font-size: 14px">    
+    <div id="figure1" data-idd-plot="figure" style="width: 400px; height: 300px; float:left"
+        data-idd-navigation-enabled="true" data-idd-legend-enabled="true">
+        <div id="grid1" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'
+            data-idd-xaxis='bottom_axis1'></div>
+        <div id="bottom_axis1" data-idd-axis="numeric" data-idd-placement="bottom" style="position: relative;"></div>
+    </div>
+</body>
+</html>

--- a/src/idd/idd.axis.js
+++ b/src/idd/idd.axis.js
@@ -825,6 +825,49 @@ InteractiveDataDisplay.TickSource = function () {
     this.start;
     this.finish;
 
+    this.getInScientificNotation = function (floatNumber){
+        var decPow = 0;
+        var unsignedInner = Math.abs(floatNumber);
+        var innerSign = floatNumber < 0 ? -1 : 1;
+        if(unsignedInner > 1){
+            while(unsignedInner >= 10){
+                decPow++;
+                unsignedInner = unsignedInner/10;
+            }
+        }
+        else if(unsignedInner <= 1){
+            while(unsignedInner < 1 && unsignedInner != 0){
+                decPow--;
+                unsignedInner = unsignedInner*10;
+            }
+        }
+
+        var resultStr = "";
+        if(unsignedInner != 0) resultStr += innerSign*unsignedInner;
+        else resultStr = "0";
+        if(decPow != 0) resultStr += "&#215;10<sup>" + decPow + "</sup>";
+        return resultStr;
+    };
+
+    this.insertNumericTick = function (divjq, inner){
+        var precision = 2;
+        divjq.empty();
+        if(typeof inner !== "string"){
+            divjq.append(inner);
+        }else{
+            var innerParsed = parseFloat(inner);
+            if(isNaN(innerParsed)){
+                divjq.text(inner);
+            }
+            else{
+                if(Math.abs(innerParsed) < Math.pow(10,-precision) || Math.abs(innerParsed) >= Math.pow(10,precision+1))
+                    divjq.append(this.getInScientificNotation(innerParsed));
+                else
+                    divjq.text(innerParsed);
+            }
+        }
+    }
+
     // gets first available div (not used) or creates new one
     this.getDiv = function (x) {
         var inner = this.getInner(x);
@@ -842,52 +885,15 @@ InteractiveDataDisplay.TickSource = function () {
                 isUsedPool[i] = true;
                 styles[i].display = "block";
                 inners[i] = inner;
-                var $div = divPool[i];
-                if(typeof inner !== "string"){
-                    $div.empty();
-                    $div.append(inner);
-                }else{
-                    $div.text(inner);
-                }
+                var $div = divPool[i];                
+                this.insertNumericTick($div, inner);
                 var div = $div[0];
                 $div._size = { width: div.offsetWidth, height: div.offsetHeight };
                 return divPool[i];
             }
             else {
                 var $div = $("<div></div>");
-                if(typeof inner !== "string"){
-                    $div.append(inner);
-                }else{
-                    var innerParsed = parseFloat(inner);
-                    if(isNaN(innerParsed)){
-                        $div.text(inner);
-                    }
-                    else{
-                        var floatPrecision = 3;
-                        var decPow = 0;
-                        var unsignedInner = Math.abs(innerParsed);
-                        var innerSign = Math.sign(innerParsed);
-                        if(unsignedInner > 1){
-                            while(unsignedInner > 10){
-                                decPow++;
-                                unsignedInner = unsignedInner/10;
-                            }
-                        }
-                        else if(unsignedInner <= 1){
-                            while(unsignedInner < 1 && unsignedInner != 0){
-                                decPow--;
-                                unsignedInner = unsignedInner*10;
-                            }
-                        }
-
-                        var resultStr = "";
-                        if(unsignedInner != 0) resultStr += innerSign*unsignedInner.toPrecision(floatPrecision);
-                        else resultStr = "0";
-                        if(decPow != 0) resultStr += " * 10<sup>" + decPow + "</sup>";
-
-                        $div.append(resultStr);
-                    }
-                }
+                this.insertNumericTick($div, inner);
                 isUsedPool[len] = true;
                 divPool[len] = $div;
                 inners[len] = inner;

--- a/src/idd/idd.axis.js
+++ b/src/idd/idd.axis.js
@@ -858,7 +858,35 @@ InteractiveDataDisplay.TickSource = function () {
                 if(typeof inner !== "string"){
                     $div.append(inner);
                 }else{
-                    $div.text(inner);
+                    var innerParsed = parseFloat(inner);
+                    if(isNaN(innerParsed)){
+                        $div.text(inner);
+                    }
+                    else{
+                        var floatPrecision = 3;
+                        var decPow = 0;
+                        var unsignedInner = Math.abs(innerParsed);
+                        var innerSign = Math.sign(innerParsed);
+                        if(unsignedInner > 1){
+                            while(unsignedInner > 10){
+                                decPow++;
+                                unsignedInner = unsignedInner/10;
+                            }
+                        }
+                        else if(unsignedInner <= 1){
+                            while(unsignedInner < 1 && unsignedInner != 0){
+                                decPow--;
+                                unsignedInner = unsignedInner*10;
+                            }
+                        }
+
+                        var resultStr = "";
+                        if(unsignedInner != 0) resultStr += innerSign*unsignedInner.toPrecision(floatPrecision);
+                        else resultStr = "0";
+                        if(decPow != 0) resultStr += " * 10<sup>" + decPow + "</sup>";
+
+                        $div.append(resultStr);
+                    }
                 }
                 isUsedPool[len] = true;
                 divPool[len] = $div;


### PR DESCRIPTION
added support for data-idd-scientific-notation attribute on numeric axes. With this feature enabled ticks are represented in a form: m × 10ⁿ, where 1≤m≤9 for numbers(modulo): ≥10³ that divisible exactly by 10³, or <10⁻³ 