### PR TITLE
Tooltip delay

### DIFF
--- a/samples/LabelledAxisSVGSample.html
+++ b/samples/LabelledAxisSVGSample.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10; IE=Edge" />
+    <title>Labelled axis SVG export sample</title>
+    <link rel="stylesheet" type="text/css" href="../dist/idd.css" />
+    <link rel="stylesheet" type="text/css" href="../src/css/IDDTheme.css" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/3.1.2/rx.lite.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.4.0/svg.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script> 
+    <script src="../dist/idd.js"></script>
+
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var plot1 = InteractiveDataDisplay.asPlot($("#figure1"));
+            var plot2 = InteractiveDataDisplay.asPlot($("#figure2"));
+        });
+
+        var exportSvg = function(n){
+            var plot = InteractiveDataDisplay.asPlot($("#figure"+n));
+            var svg = plot.exportToSvg();
+            
+            $("#plot"+n+"_svg").html(svg.svg());
+        };
+
+    </script>
+</head>
+<body style="font-family: Segoe UI; font-size: 14px">    
+    <div style="display: inline-grid">        
+        <b>Labelled axis</b>
+        <div id="figure1" data-idd-plot="figure" style="width: 400px; height: 300px; float:left"
+            data-idd-navigation-enabled="true" data-idd-legend-enabled="true">
+
+            <div id="grid1" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'
+                data-idd-xaxis='bottom_axis1' data-idd-yaxis='left_axis1'></div>
+
+            <div data-idd-plot="polyline" data-idd-style="stroke: red; thickness: 3" id="red line">
+                x   y
+                1   1
+                2   2
+                3   1
+                4   2
+                5   1
+            </div>
+
+            <div id="bottom_axis1" data-idd-axis="labels" data-idd-placement="bottom" style="position: relative;">
+                ticks  labels  rotateAngle
+                1   abc   60
+                2   bbc
+                3   cbc
+                4   dbc
+                5   
+            </div>
+            <div id="left_axis1" data-idd-axis="numeric" data-idd-placement="left" style="position: relative;"></div>
+        </div>
+        <div id="plot1_svg" style="display: inline-grid; width: 400px; height: 300px; margin: 20 0 20 0; background-color: rgb(240, 214, 231);" onclick="exportSvg(1); $('#plot1_svg').css('background-color', 'transparent');">
+            Every time you click here you get an SVG snapshot of the chart below.
+        </div>
+    </div>
+    <div style="display: inline-grid">
+            <b>Labelled axis 2</b>
+            <div id="figure2" data-idd-plot="figure" style="width: 400px; height: 300px; float:left"
+                data-idd-navigation-enabled="true" data-idd-legend-enabled="true">
+    
+                <div id="grid2" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'
+                    data-idd-xaxis='bottom_axis2' data-idd-yaxis='left_axis2'></div>
+    
+                <div data-idd-plot="polyline" data-idd-style="stroke: red; thickness: 3" id="red line">
+                    x   y
+                    1   1
+                    2   2
+                    3   1
+                    4   2
+                    5   1
+                </div>
+    
+                <div id="bottom_axis2" data-idd-axis="labels" data-idd-placement="bottom" style="position: relative;" data-idd-datasource="InteractiveDataDisplay.readBase64">
+                    ticks int32.1D AQAAAAMAAAAIAAAAAgAAAAQAAAA=
+                    labels string.1D YSxiLGMsZCxl
+                </div>
+                <div id="left_axis2" data-idd-axis="numeric" data-idd-placement="left" style="position: relative;"></div>
+            </div>
+            <div id="plot2_svg" style="display: inline-grid; width: 400px; height: 300px; margin: 20 0 20 0; background-color: rgb(214, 240, 214);" onclick="exportSvg(2); $('#plot2_svg').css('background-color', 'transparent');">
+                Every time you click here you get an SVG snapshot of the chart below.
+            </div>
+    </div>
+</body>
+</html>

--- a/samples/Subplots.html
+++ b/samples/Subplots.html
@@ -31,7 +31,7 @@
     </style>
     <script type="text/javascript">
         $(document).ready(function () {
-            var subplots = new InteractiveDataDisplay.SubPlots(document.getElementById('table1'));
+            var subplots = InteractiveDataDisplay.asSubPlots(document.getElementById('table1'));
 
             //plot11.host.on("visibleRectChanged", function(event,newPlotRect) {   
                 

--- a/samples/Subplots.html
+++ b/samples/Subplots.html
@@ -50,12 +50,38 @@
     </script>
 </head>
 <body>
-    <table id='table1'>        
+    <table id='table1'>
         <tr><td></td><td><div class="idd-subplot-title">Plot 11 individual title</div class="idd-subplot-title"></td><td></td><td></td><td></td><td></td></tr>
-        <tr><td><div data-idd-axis="numeric" data-idd-placement="left" id="left_axis1"  data-idd-scientific-notation="true" style="height: 300px;"></div></td><td><div id="plot11" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
+        <tr><td><div data-idd-axis="numeric" data-idd-placement="left" id="left_axis1"  data-idd-scientific-notation="true" style="height: 300px;"></div></td>
+            <td>
+                <div id="plot11" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false; tooltipDelay:0;" style="width: 600px; height: 300px;">
+                    <div data-idd-plot='subplots-trap'></div>
+                    <div id="grid11" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
+                    <div data-idd-plot="polyline">
+                        x   y
+                        0   0
+                        0.1 0.031410759
+                        0.2 0.06279052
+                        0.3 0.094108313
+                        0.4 0.125333234
+                        0.5 0.156434465
+                        0.6 0.187381315
+                        0.7 0.218143241
+                        0.8 0.248689887
+                        0.9 0.278991106
+                        1   0.309016994
+                        1.1 0.33873792
+                        1.2 0.368124553
+                        1.3 0.397147891
+                        1.4 0.425779291
+                    </div>
+                </div>
+            </td>
+            <td></td><td></td>
+            <td><div id="plot12" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
                 <div data-idd-plot='subplots-trap'></div>
-                <div id="grid11" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
-                <div data-idd-plot="polyline">
+                <div id="grid12" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
+                <div data-idd-plot="markers">
                     x   y
                     0   0
                     0.1 0.031410759
@@ -73,31 +99,13 @@
                     1.3 0.397147891
                     1.4 0.425779291
                 </div>
-    </div></td><td></td><td></td><td><div id="plot12" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
-            <div data-idd-plot='subplots-trap'></div>
-            <div id="grid12" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
-            <div data-idd-plot="markers">
-                x   y
-                0   0
-                0.1 0.031410759
-                0.2 0.06279052
-                0.3 0.094108313
-                0.4 0.125333234
-                0.5 0.156434465
-                0.6 0.187381315
-                0.7 0.218143241
-                0.8 0.248689887
-                0.9 0.278991106
-                1   0.309016994
-                1.1 0.33873792
-                1.2 0.368124553
-                1.3 0.397147891
-                1.4 0.425779291
-            </div>
-        </div></td><td></td></tr>
+            </div></td>
+            <td></td>
+        </tr>
         <tr><td></td><td></td><td></td><td></td><td></td><td></td></tr>
         <tr><td></td><td></td><td></td><td></td><td><div class="idd-subplot-title">plot 22 individual title</div class="idd-subplot-title"></td><td></td></tr>
-        <tr><td><div data-idd-axis="numeric" data-idd-placement="left" id="left_axis2" data-idd-scientific-notation="true" style="height: 300px;"></div></td><td><div id="plot21" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
+        <tr><td><div data-idd-axis="numeric" data-idd-placement="left" id="left_axis2" data-idd-scientific-notation="true" style="height: 300px;"></div></td>
+            <td><div id="plot21" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
                 <div data-idd-plot='subplots-trap'></div>
                 <div id="grid21" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
                 <div data-idd-plot="markers">
@@ -118,28 +126,31 @@
                     1.3 0.397147891
                     1.4 0.425779291
                 </div>
-            </div></td><td></td><td></td><td><div id="plot22" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
-                    <div data-idd-plot='subplots-trap'></div>
-                    <div id="grid22" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
-                    <div data-idd-plot="polyline">
-                        x   y
-                        0   0
-                        0.1 0.031410759
-                        0.2 0.06279052
-                        0.3 0.094108313
-                        0.4 0.125333234
-                        0.5 0.156434465
-                        0.6 0.187381315
-                        0.7 0.218143241
-                        0.8 0.248689887
-                        0.9 0.278991106
-                        1   0.309016994
-                        1.1 0.33873792
-                        1.2 0.368124553
-                        1.3 0.397147891
-                        1.4 0.425779291
-                    </div>
-                </div></td><td></td></tr>
+            </div></td>
+            <td></td><td></td><td><div id="plot22" data-idd-plot="plot" data-idd-navigation-enabled="true" data-idd-style="isLegendVisible:false;" style="width: 600px; height: 300px;">
+                <div data-idd-plot='subplots-trap'></div>
+                <div id="grid22" data-idd-plot='grid' data-idd-placement='center' data-idd-style='stroke: DarkGray; thickness: 1px;'></div>
+                <div data-idd-plot="polyline">
+                    x   y
+                    0   0
+                    0.1 0.031410759
+                    0.2 0.06279052
+                    0.3 0.094108313
+                    0.4 0.125333234
+                    0.5 0.156434465
+                    0.6 0.187381315
+                    0.7 0.218143241
+                    0.8 0.248689887
+                    0.9 0.278991106
+                    1   0.309016994
+                    1.1 0.33873792
+                    1.2 0.368124553
+                    1.3 0.397147891
+                    1.4 0.425779291
+                </div>
+            </div></td>
+            <td></td>
+        </tr>
         <tr><td></td><td><div data-idd-axis="numeric" data-idd-placement="bottom" id="bottom_axis1" data-idd-scientific-notation="true" style="width: 600px;"></div></td><td></td><td></td><td><div data-idd-axis="numeric" data-idd-placement="bottom" id="bottom_axis2" data-idd-scientific-notation="true" style="width: 600px;"></div></td><td></td></tr>
     </table>
     

--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -285,10 +285,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
         // Note: data-idd-visible-region attribute is handled at the end of the constructor, as it needs more plot objects to be defined and valid 
         if (div) {
             _name = div.attr("data-idd-name") || div.attr("id") || "";
-            if(div.attr("data-idd-ignored-by-fit-to-view")) {
-                div.removeAttr("data-idd-ignored-by-fit-to-view");
-                _isIgnoredByFitToView = true;
-            }
+
             if(div.attr("data-idd-X-log")) {                
                 div.removeAttr("data-idd-X-log");                
                 _xDataTransform = InteractiveDataDisplay.logTransform;
@@ -297,15 +294,27 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                 div.removeAttr("data-idd-Y-log");                
                 _yDataTransform = InteractiveDataDisplay.logTransform;
             }
-            if(div.attr("data-idd-padding")) {
-                _padding = Number(div.attr("data-idd-padding"))
-                div.removeAttr("data-idd-padding");             
+
+            var style = {};
+            InteractiveDataDisplay.Utils.readStyle(div, style);
+            if(style.hasOwnProperty("padding")) {
+                _padding = Number(style["padding"]);
             }
-            if(div.attr("data-idd-suppress-tooltip-coords")) {                
-                div.removeAttr("data-idd-suppress-tooltip-coords");                
-                _tooltipSettings = _tooltipSettings || {}
-                _tooltipSettings.showCursorCoordinates = false
+            if(style.hasOwnProperty("suppress-tooltip-coords")) {
+                _tooltipSettings = _tooltipSettings || {};
+                _tooltipSettings.showCursorCoordinates = Boolean(style["suppress-tooltip-coords"]);
             }
+            if(style.hasOwnProperty("ignored-by-fit-to-view")) {
+                _isIgnoredByFitToView = Boolean(style["ignored-by-fit-to-view"]);
+            }
+            _tooltipSettings = _tooltipSettings || {};
+            if(style.hasOwnProperty("tooltipDelay")) {
+                _tooltipSettings.tooltipDelay = Number(style["tooltipDelay"]);
+            }
+            else
+                _tooltipSettings.tooltipDelay = InteractiveDataDisplay.TooltipDuration * 1000;
+
+
             div[0].plot = this; // adding a reference to the initialized DOM object of the plot, pointing to the plot instance.
 
             // Disables user selection for this element:
@@ -1473,7 +1482,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                     localTooltip.fadeOutTimer = setTimeout(function () {
                         _updateTooltip = undefined;
                         localTooltip.fadeOut('fast');
-                    }, InteractiveDataDisplay.TooltipDuration * 1000);
+                    }, _tooltipSettings.tooltipDelay);
                 });
             };
 
@@ -1506,7 +1515,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                 clearTooltip();
 
                 if (that.master.isToolTipEnabled) {
-                    _tooltipTimer = setTimeout(function () { onShowTooltip(originHost, p); }, InteractiveDataDisplay.TooltipDelay * 1000);
+                    _tooltipTimer = setTimeout(function () { onShowTooltip(originHost, p); }, _tooltipSettings.tooltipDelay);
                 }
 
                 var onmousemove_rec = function (plot, origin_s, origin_p) {

--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -312,7 +312,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                 _tooltipSettings.tooltipDelay = Number(style["tooltipDelay"]);
             }
             else
-                _tooltipSettings.tooltipDelay = InteractiveDataDisplay.TooltipDuration * 1000;
+                _tooltipSettings.tooltipDelay = InteractiveDataDisplay.TooltipDuration * 100;
 
 
             div[0].plot = this; // adding a reference to the initialized DOM object of the plot, pointing to the plot instance.
@@ -1482,7 +1482,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                     localTooltip.fadeOutTimer = setTimeout(function () {
                         _updateTooltip = undefined;
                         localTooltip.fadeOut('fast');
-                    }, _tooltipSettings.tooltipDelay);
+                    }, InteractiveDataDisplay.TooltipDuration * 1000);
                 });
             };
 

--- a/src/idd/idd.ko.js
+++ b/src/idd/idd.ko.js
@@ -57,10 +57,10 @@
                     if(typeof element.plot != 'undefined') {
                         element.plot.isIgnoredByFitToView = unwrappedName;
                     }
-                    else { //the case when the element was not yet initialized and not yet bound to the logical entity (plot)
-                        //storing the data in the DOM. it will be used by IDD during IDD-initializing of the dom element                        
-                        element.setAttribute("data-idd-ignored-by-fit-to-view", unwrappedName);
-
+                    else {
+                        //the case when the element was not yet initialized and not yet bound to the logical entity (plot)
+                        //storing the data in the DOM. it will be used by IDD during IDD-initializing of the dom element
+                        InteractiveDataDisplay.Utils.updateStyle(element, style, "ignored-by-fit-to-view", unwrappedName);
                     }
                 }
             }

--- a/src/idd/idd.utils.js
+++ b/src/idd/idd.utils.js
@@ -166,6 +166,23 @@ InteractiveDataDisplay.Utils =
             }
         },
 
+        // Updates one of property values in data-idd-style
+        updateStyle: function (jqElement, styleObj, propName, propVal) {
+            var styleObj = InteractiveDataDisplay.Utils.readStyle(jqElement, styleObj);
+
+            if (!styleObj){
+                styleObj = {};
+            }
+            styleObj[propName] = propVal;
+
+            var updatedStyleStr = "";
+            $.each( styleObj, function( key, value ) {
+                updatedStyleStr += key + ": " + value + "; "; 
+            });
+
+            jqElement.attr("data-idd-style", updatedStyleStr);
+        },
+
         getDataSourceFunction: function (jqElem, defaultSource) {
             var source = jqElem.attr("data-idd-datasource");
             if (source == "InteractiveDataDisplay.readTable")


### PR DESCRIPTION
- tooltip delay can be changed for a Plot by setting "tooltipDelay" property of the "data-idd-style" attribute. Closes #165
- added sample for an SVG export of labelled axes for a #118
- moved padding, suppress-tooltip-coords, ignored-by-fit-to-view Plot settings to the data-idd-style attribute value