### PR TITLE
Chaning main script to idd.webpack.js

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 1.5.33 (July 30, 2019)
+
+New features:
+ - idd.webpack.js is now used as an main file in NPM package
+
 ### 1.5.32 (July 18, 2019)
 
 New features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-data-display",
-  "version": "1.5.32",
+  "version": "1.5.33",
   "license": "Apache-2.0",
   "homepage": "https://github.com/predictionmachines/InteractiveDataDisplay/wiki",
   "description": "A JavaScript visualization library for dynamic data",
@@ -11,7 +11,7 @@
     "chart",
     "plot"
   ],
-  "main": "/dist/idd.js",
+  "main": "/dist/idd.webpack.js",
   "dependencies": {
     "file-saver": "~1.3.3",
     "jasmine": "~2.99.0",


### PR DESCRIPTION
Changing main script from idd.js to idd.webpack.js will enable proper operation of the webpack bundling.
Initially requested by @FilippoPolo, this can enable IDD to be used in the tools that @FilippoPolo is currently working on.

According to [NPM Docs](https://docs.npmjs.com/files/package.json#main)

> The main field is a module ID that is the primary entry point to your program. That is, if your package is named foo, and a user installs it, and then does require("foo"), then your main module’s exports object will be returned. 

Original idd.js is not suitable to be imported via require(...) at all, thus changing it seems to be practical.
