### PR TITLE
Support for dashed polyline plot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 1.5.35 (November 12, 2019)
+
+New features:
+ - Added dash lines support. Choose from dash patterns: "dot", "dash", "dash dot", "long dash", "long dash dot", "long dash dot dot"; or define a set of number pairs: [ dash_length1, space1, dash_length2, space2, ... ]. Knockout binding - iddLineDash.
+
 ### 1.5.34 (July 30, 2019)
 
 Bugfix:
@@ -18,12 +23,12 @@ New features:
 ### 1.5.31 (July 17, 2019)
 
 New features:
- - new bundle idd.webpack.js file distributed with release. It uses dependecy names that match npm packages. It is also referencess CSS dependency directly without "css!" requireJS extension.
+ - new bundle idd.webpack.js file distributed with release. It uses dependency names that match npm packages. It is also references CSS dependency directly without "css!" requireJS extension.
 
 ### 1.5.30 (March 15, 2019)
 
 Fixes:
- - Regression of legend behaviour of legend in Figure and Chart (e.g. not specifing all of the Legend constructor parameters)
+ - Regression of legend behavior of legend in Figure and Chart (e.g. not specifying all of the Legend constructor parameters)
 
 New features:
  - Ability to force the display of all labels on the axis (even if the overlay) for the labelled axis

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-data-display",
-  "version": "1.5.34",
+  "version": "1.5.35",
   "license": "Apache-2.0",
   "homepage": "https://github.com/predictionmachines/InteractiveDataDisplay/wiki",
   "description": "A JavaScript visualization library for dynamic data",

--- a/samples/DashedPolyline.html
+++ b/samples/DashedPolyline.html
@@ -24,26 +24,25 @@
         var state = 1;
         var isVisible = true;
 
-        var xData = [0, 0.3, 0.8];
-
         $(document).ready(function () {
 
             chart = InteractiveDataDisplay.asPlot($("#chart"));
             polyline1 = chart.get("line1");
             polyline1.draw({
-                x: xData,
+                x: [0, 0.3, 0.8],
                 y: [-1, 1, 0.0],
                 thickness: 4,
                 lineCap: 'round',
                 lineJoin: 'round',
-                lineDash: [5, 10]
+                lineDash: [5, 10],
+                stroke: 'turquoise'
             });       
         });
     </script>
 </head>
 <body>
     <div id="chart" data-idd-plot="chart" style="width: 800px; height: 400px; margin: 50px 0 0 0">
-        <div id="line1" data-idd-plot="polyline" data-idd-style="stroke: blue"></div>
+        <div id="line1" data-idd-plot="polyline"></div>
     </div>
 </body>
 </html>

--- a/samples/DashedPolyline.html
+++ b/samples/DashedPolyline.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10; IE=Edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Dashed polyline sample page</title>
+    <link rel="stylesheet" type="text/css" href="../dist/idd.css" />
+    <link rel="stylesheet" type="text/css" href="../src/css/IDDTheme.css" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/3.1.2/rx.lite.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.4.0/svg.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script> 
+    <script src="../dist/idd.js"></script>
+
+    <script type="text/javascript">
+        var chart, figure, markersChart;
+        var polyline1, polyline2;
+        var remove = false;
+        var state = 1;
+        var isVisible = true;
+
+        var xData = [0, 0.3, 0.8];
+
+        $(document).ready(function () {
+
+            chart = InteractiveDataDisplay.asPlot($("#chart"));
+            polyline1 = chart.get("line1");
+            polyline1.draw({
+                x: xData,
+                y: [-1, 1, 0.0],
+                thickness: 4,
+                lineCap: 'round',
+                lineJoin: 'round',
+                lineDash: [5, 10]
+            });       
+        });
+    </script>
+</head>
+<body>
+    <div id="chart" data-idd-plot="chart" style="width: 800px; height: 400px; margin: 50px 0 0 0">
+        <div id="line1" data-idd-plot="polyline" data-idd-style="stroke: blue"></div>
+    </div>
+</body>
+</html>

--- a/samples/KO.DashedPolyline.html
+++ b/samples/KO.DashedPolyline.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10; IE=Edge" />
+    <title>Dashed polyline with Knockout</title>
+    <link rel="stylesheet" type="text/css" href="../dist/idd.css" />
+    <link rel="stylesheet" type="text/css" href="../src/css/IDDTheme.css" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/3.1.2/rx.lite.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.4.0/svg.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script> 
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.4.1/knockout-min.js"></script> 
+    <script src="../dist/idd_knockout.js"></script>
+
+    <script type="text/javascript">
+		var x_values = [2.0,3.0,4.0,5.0] 
+		var y_values = [1.0,5.0,1.0,2.0]
+		
+        var vm = {
+			X : ko.observable(x_values),
+			Y : ko.observable(y_values),
+
+            ActiveColour : ko.observable("Green"),            
+            ColoursToChoose: ["Red","Green","Blue","Black"],
+
+            Thickness: ko.observable(1),
+
+            LineCap: ko.observable("round"),
+            LineCapsToChoose: ["butt","round","square"],
+
+            LineJoin: ko.observable("round"),
+            LineJoinsToChoose: ["bevel", "round", "miter"],
+
+            LineDashManual: ko.observable([1,1]),
+            LineDashManualChoice: [ [2,2], [10, 5], [10, 5, 2, 5], [25, 10], [25, 10, 2, 10], [25, 10, 2, 10, 2, 10] ],
+
+            LineDashWords: ko.observable("dot"),
+            LineDashWordsChoice: [ "dot", "dash", "dash dot", "long dash", "long dash dot", "long dash dot dot" ]
+		}
+		
+        $(document).ready(function () {
+            var chart = InteractiveDataDisplay.asPlot($("#chart"));
+			
+            ko.applyBindings(vm)
+        });
+        
+        var exportSvg = function(){
+            var chart = InteractiveDataDisplay.asPlot($("#chart"));
+            var svg = chart.exportToSvg();
+            
+            $("#chart_svg").html(svg.svg());   
+            $("#output").text(svg.svg());         
+        };
+    </script>
+</head>
+<body>
+    <div style="display: inline-block">
+        <div id="chart" data-idd-plot="chart" style="width: 600px; height: 400px; float:left">
+            <div data-idd-plot="polyline"
+                data-idd-name="Line 1"
+                data-bind="
+                    iddX: X,
+                    iddY: Y,
+                    iddStroke: ActiveColour,
+                    iddThickness: Thickness,
+                    iddLineCap: LineCap,
+                    iddLineJoin: LineJoin,
+                    iddLineDash: LineDashManual">				
+            </div>
+            <div data-idd-plot="polyline"
+                data-idd-name="Line 2"
+                data-bind="
+                    iddX: Y,
+                    iddY: X,
+                    iddStroke: ActiveColour,
+                    iddThickness: Thickness,
+                    iddLineCap: LineCap,
+                    iddLineJoin: LineJoin,
+                    iddLineDash: LineDashWords">				
+            </div>
+        </div>
+        <div style="float: right; margin: 2em">
+            <p>Colour:
+                <select data-bind="options: ColoursToChoose, value: ActiveColour"></select>
+            </p>        
+            <p>Thickness:
+                <input data-bind="value: Thickness" type="number" min="1" max="30">
+            </p>
+            <p>Line join:
+                <select data-bind="options: LineJoinsToChoose, value: LineJoin"></select>
+            </p>
+            <p>Line cap:
+                <select data-bind="options: LineCapsToChoose, value: LineCap"></select>
+            </p>
+            <p>Line dash set by one of special words for the 'horizontal' polyline:
+                <select data-bind="options: LineDashWordsChoice, value: LineDashWords"></select>
+            </p>
+            <p>Line dash set by [dash length, space] for the 'vertical' polyline:
+                <select data-bind="options: LineDashManualChoice, value: LineDashManual"></select>
+            </p>
+        </div>
+        <div id="chart_svg" style="width: 600px; height: 400px; margin-bottom: 5px; background-color: azure;" onclick="exportSvg(); $('#chart_svg').css('background-color', 'transparent');">
+            Every time you click here you get an SVG snapshot of the chart above.
+        </div>
+    </div>
+</body>
+</html>

--- a/samples/KO.DashedPolyline.html
+++ b/samples/KO.DashedPolyline.html
@@ -75,7 +75,7 @@
     <div style="display: inline-block">
         <div id="chart" data-idd-plot="chart" style="width: 600px; height: 400px; float:left">
             <div data-idd-plot="polyline"
-                data-idd-name="Lower line"
+                data-idd-name="Line"
                 data-bind="
                     iddX: X,
                     iddY: Y2,

--- a/samples/KO.DashedPolyline.html
+++ b/samples/KO.DashedPolyline.html
@@ -18,29 +18,42 @@
     <script src="../dist/idd_knockout.js"></script>
 
     <script type="text/javascript">
-		var x_values = [2.0,3.0,4.0,5.0] 
-		var y_values = [1.0,5.0,1.0,2.0]
+		var x_values = [2.0,3.0,4.0,5.0]
+		var y1_values = [1.0,5.0,1.0,2.0]
+		var y2_values = [8.0,12.0,8.0,9.0]
+		var sd_values = [0.2,0.3,0.5,1.1]
+		
+		var ub_68 = y1_values.map(function(elem,i) { return elem + sd_values[i] });
+		var lb_68 = y1_values.map(function(elem,i) { return elem - sd_values[i] });
+		var ub_95 = y1_values.map(function(elem,i) { return elem + sd_values[i]*2 });
+		var lb_95 = y1_values.map(function(elem,i) { return elem - sd_values[i]*2 });
 		
         var vm = {
 			X : ko.observable(x_values),
-			Y : ko.observable(y_values),
+			Y1 : ko.observable(y1_values),
+			Y2 : ko.observable(y2_values),
 
             ActiveColour : ko.observable("Green"),            
             ColoursToChoose: ["Red","Green","Blue","Black"],
 
             Thickness: ko.observable(1),
 
-            LineCap: ko.observable("round"),
+            LineCap: ko.observable("butt"),
             LineCapsToChoose: ["butt","round","square"],
 
             LineJoin: ko.observable("round"),
             LineJoinsToChoose: ["bevel", "round", "miter"],
 
             LineDashManual: ko.observable([1,1]),
-            LineDashManualChoice: [ [2,2], [10, 5], [10, 5, 2, 5], [25, 10], [25, 10, 2, 10], [25, 10, 2, 10, 2, 10] ],
+            LineDashManualChoice: [ [2,2], [10, 5], [10, 5, 2, 5], [25, 10], [25, 10, 2, 10], [25, 10, 2, 10, 2, 10], [], [3.7, 10.6], [2, 6, "a", 9, 8, 3] ],
 
             LineDashWords: ko.observable("dot"),
-            LineDashWordsChoice: [ "dot", "dash", "dash dot", "long dash", "long dash dot", "long dash dot dot" ]
+            LineDashWordsChoice: [ "dot", "dash", "dash dot", "long dash", "long dash dot", "long dash dot dot", "", "3 a 6 7" ],
+
+			ub_68: ub_68,
+			lb_68: lb_68,
+			ub_95: ub_95,
+			lb_95: lb_95
 		}
 		
         $(document).ready(function () {
@@ -62,26 +75,33 @@
     <div style="display: inline-block">
         <div id="chart" data-idd-plot="chart" style="width: 600px; height: 400px; float:left">
             <div data-idd-plot="polyline"
-                data-idd-name="Line 1"
+                data-idd-name="Lower line"
                 data-bind="
                     iddX: X,
-                    iddY: Y,
-                    iddStroke: ActiveColour,
-                    iddThickness: Thickness,
-                    iddLineCap: LineCap,
-                    iddLineJoin: LineJoin,
-                    iddLineDash: LineDashManual">				
-            </div>
-            <div data-idd-plot="polyline"
-                data-idd-name="Line 2"
-                data-bind="
-                    iddX: Y,
-                    iddY: X,
+                    iddY: Y2,
                     iddStroke: ActiveColour,
                     iddThickness: Thickness,
                     iddLineCap: LineCap,
                     iddLineJoin: LineJoin,
                     iddLineDash: LineDashWords">				
+            </div>
+            <div data-idd-plot="polyline"
+                data-idd-name="Line with a band"
+                data-bind="
+                    iddX: X,
+                    iddStroke: ActiveColour,
+                    iddThickness: Thickness,
+                    iddLineCap: LineCap,
+                    iddLineJoin: LineJoin,
+                    iddLineDash: LineDashManual,
+                    iddYMedian: Y1,
+                    iddLower68: lb_68,
+                    iddUpper68: ub_68,
+                    iddLower95: lb_95,
+                    iddUpper95: ub_95,
+                    iddFill95: 'rgb(190, 255, 212)',
+                    iddFill68: 'aquamarine'
+                    ">				
             </div>
         </div>
         <div style="float: right; margin: 2em">
@@ -97,10 +117,10 @@
             <p>Line cap:
                 <select data-bind="options: LineCapsToChoose, value: LineCap"></select>
             </p>
-            <p>Line dash set by one of special words for the 'horizontal' polyline:
+            <p>Line dash set by one of special words for the upper polyline:
                 <select data-bind="options: LineDashWordsChoice, value: LineDashWords"></select>
             </p>
-            <p>Line dash set by [dash length, space] for the 'vertical' polyline:
+            <p>Line dash set by [dash length, space] for the lower polyline:
                 <select data-bind="options: LineDashManualChoice, value: LineDashManual"></select>
             </p>
         </div>

--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -2411,6 +2411,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
         var _stroke = '#4169ed';
         var _lineCap = 'butt';
         var _lineJoin = 'miter';
+        var _lineDash = [];
 
         // default styles:
         if (initialData) {
@@ -2420,6 +2421,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             _lineJoin = typeof initialData.lineJoin != "undefined" ? initialData.lineJoin : _lineJoin;
             _fill68 = typeof initialData.fill68 != "undefined" ? initialData.fill68 : _fill68;
             _fill95 = typeof initialData.fill95 != "undefined" ? initialData.fill95 : _fill95;
+            _lineDash = typeof initialData.lineDash != "undefined" ? initialData.lineDash : _lineDash;
         }
 
         this.draw = function (data) {
@@ -2533,6 +2535,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             _lineJoin = typeof data.lineJoin != "undefined" ? data.lineJoin : _lineJoin;
             _fill68 = typeof data.fill68 != "undefined" ? data.fill68 : _fill68;
             _fill95 = typeof data.fill95 != "undefined" ? data.fill95 : _fill95;
+            _lineDash = typeof data.lineDash != "undefined" ? data.lineDash : _lineDash;
 
             this.invalidateLocalBounds();
 
@@ -2605,6 +2608,30 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             context.lineWidth = _thickness;
             context.lineCap = _lineCap;
             context.lineJoin = _lineJoin;
+
+            switch (_lineDash){
+                case "dot":
+                    _lineDash = [_thickness, 2 * _thickness];
+                    break;
+                case "dash":
+                    _lineDash = [3 * _thickness, 2 * _thickness];
+                    break;
+                case "dash dot":
+                    _lineDash = [3 * _thickness, 2 * _thickness, _thickness, 2 * _thickness];
+                    break;
+                case "long dash":
+                    _lineDash = [8 * _thickness, 2 * _thickness];
+                    break;
+                case "long dash dot":
+                        _lineDash = [8 * _thickness, 2 * _thickness, _thickness, 2 * _thickness];
+                    break;
+                case "long dash dot dot":
+                    _lineDash = [8 * _thickness, 2 * _thickness, _thickness, 2 * _thickness, _thickness, 2 * _thickness];
+                    break;
+                default:
+                    break;
+            }
+            context.setLineDash(_lineDash);
 
             context.beginPath();
             var x1, x2, y1, y2;
@@ -2731,10 +2758,8 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             var strokeRgba = InteractiveDataDisplay.ColorPalette.colorFromString(_stroke)
             var strokeColor = 'rgb('+strokeRgba.r+','+strokeRgba.g+','+strokeRgba.b+')'
     
-
-
             var drawSegment = function () {
-                svg.polyline(segment).style({ fill: "none", stroke: strokeColor, "stroke-width": _thickness, 'stroke-opacity':strokeRgba.a });
+                svg.polyline(segment).style({ fill: "none", stroke: strokeColor, "stroke-width": _thickness, 'stroke-opacity': strokeRgba.a, 'stroke-linecap': _lineCap}).attr("stroke-dasharray", _lineDash).attr("stroke-linejoin", _lineJoin);
             }
             // Looking for non-missing value
             var nextValuePoint = function () {
@@ -2917,6 +2942,20 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             },
             configurable: false
         });
+
+        Object.defineProperty(this, "lineDash", {
+            get: function () { return _lineDash; },
+            set: function (value) {
+                if (value == _lineDash) return;
+                _lineDash = value;
+
+                this.fireAppearanceChanged("lineDash");
+                this.requestNextFrameOrUpdate();
+            },
+            configurable: false
+        });
+
+
         this.getLegend = function () {
             var canvas = $("<canvas></canvas>");
 

--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -2586,6 +2586,40 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             $("<div></div>").addClass('idd-tooltip-name').text((this.name || "polyline")).appendTo($toolTip);
             return $toolTip;
         };
+
+        var getArrayToSetLineDash = function (ld) {
+            switch (ld){
+                case "dot":
+                    ld = [_thickness, 2 * _thickness];
+                    break;
+                case "dash":
+                    ld = [3 * _thickness, 2 * _thickness];
+                    break;
+                case "dash dot":
+                    ld = [3 * _thickness, 2 * _thickness, _thickness, 2 * _thickness];
+                    break;
+                case "long dash":
+                    ld = [8 * _thickness, 2 * _thickness];
+                    break;
+                case "long dash dot":
+                    ld = [8 * _thickness, 2 * _thickness, _thickness, 2 * _thickness];
+                    break;
+                case "long dash dot dot":
+                    ld = [8 * _thickness, 2 * _thickness, _thickness, 2 * _thickness, _thickness, 2 * _thickness];
+                    break;
+                default:
+                    break;
+            }
+            var dashArray = [];
+            for (var i = 0; i < ld.length; i=i+2){
+                if(typeof ld[i] === "number" && typeof ld[i+1] === "number"){
+                    dashArray.push(ld[i]);
+                    dashArray.push(ld[i+1]);
+                }
+            }
+            return dashArray;
+        }
+
         var renderLine = function (_x, _y, _stroke, _thickness, plotRect, screenSize, context) {
             if (_x === undefined || _y == undefined)
                 return;
@@ -2608,37 +2642,8 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             context.lineWidth = _thickness;
             context.lineCap = _lineCap;
             context.lineJoin = _lineJoin;
-
-            switch (_lineDash){
-                case "dot":
-                    _lineDash = [_thickness, 2 * _thickness];
-                    break;
-                case "dash":
-                    _lineDash = [3 * _thickness, 2 * _thickness];
-                    break;
-                case "dash dot":
-                    _lineDash = [3 * _thickness, 2 * _thickness, _thickness, 2 * _thickness];
-                    break;
-                case "long dash":
-                    _lineDash = [8 * _thickness, 2 * _thickness];
-                    break;
-                case "long dash dot":
-                        _lineDash = [8 * _thickness, 2 * _thickness, _thickness, 2 * _thickness];
-                    break;
-                case "long dash dot dot":
-                    _lineDash = [8 * _thickness, 2 * _thickness, _thickness, 2 * _thickness, _thickness, 2 * _thickness];
-                    break;
-                default:
-                    break;
-            }
-            var dashArray = [];
-            for (var i = 0; i < _lineDash.length; i=i+2){
-                if(typeof _lineDash[i] === "number" && typeof _lineDash[i+1] === "number"){
-                    dashArray.push(_lineDash[i]);
-                    dashArray.push(_lineDash[i+1]);
-                }
-            }
-            context.setLineDash(dashArray);
+            
+            context.setLineDash(getArrayToSetLineDash(_lineDash));
 
             context.beginPath();
             var x1, x2, y1, y2;
@@ -2766,7 +2771,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             var strokeColor = 'rgb('+strokeRgba.r+','+strokeRgba.g+','+strokeRgba.b+')'
     
             var drawSegment = function () {
-                svg.polyline(segment).style({ fill: "none", stroke: strokeColor, "stroke-width": _thickness, 'stroke-opacity': strokeRgba.a, 'stroke-linecap': _lineCap}).attr("stroke-dasharray", _lineDash).attr("stroke-linejoin", _lineJoin);
+                svg.polyline(segment).style({ fill: "none", stroke: strokeColor, "stroke-width": _thickness, 'stroke-opacity': strokeRgba.a, 'stroke-linecap': _lineCap}).attr("stroke-dasharray", getArrayToSetLineDash(_lineDash)).attr("stroke-linejoin", _lineJoin);
             }
             // Looking for non-missing value
             var nextValuePoint = function () {
@@ -3006,6 +3011,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             }
             ctx.strokeStyle = _stroke;
             ctx.lineWidth = _thickness;
+            ctx.setLineDash(getArrayToSetLineDash(_lineDash));
             ctx.moveTo(0, 0);
             ctx.lineTo(40, 40);
             ctx.stroke();
@@ -3029,7 +3035,6 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                         ctx.globalAlpha = 0.5;
                         ctx.strokeStyle = _fill95;
                         ctx.fillStyle = _fill95;
-
                         ctx.beginPath();
                         ctx.moveTo(0, 0);
                         ctx.lineTo(0, 20);
@@ -3058,6 +3063,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                         ctx.stroke();
                         ctx.closePath();
                     }
+                    ctx.setLineDash(getArrayToSetLineDash(_lineDash));
                     ctx.strokeStyle = _stroke;
                     ctx.lineWidth = _thickness;
                     ctx.moveTo(0, 0);
@@ -3093,7 +3099,7 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
 
             if (isUncertainData95) svg.add(svg.polyline([[0, 0], [0, 9], [9, 18], [18, 18], [18, 9], [9, 0], [0, 0]]).fill(fill95Color).opacity(fill95Rgba.a).translate(5, 5));
             if (isUncertainData68) svg.add(svg.polyline([[0, 0], [0, 4.5], [13.5, 18], [18, 18], [18, 13.5], [4.5, 0], [0, 0]]).fill(fill68Color).opacity(fill68Rgba.a).translate(5, 5));
-            svg.add(svg.line(0, 0, 18, 18).stroke({ width: _thickness, color: strokeColor }).translate(5, 5));
+            svg.add(svg.line(0, 0, 18, 18).stroke({ width: _thickness, color: strokeColor }).translate(5, 5).attr("stroke-dasharray", getArrayToSetLineDash(_lineDash)));
             var style = window.getComputedStyle(legendSettings.legendDiv.children[0].children[1], null);
             var fontSize = parseFloat(style.getPropertyValue('font-size'));
             var fontFamily = style.getPropertyValue('font-family');

--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -2631,7 +2631,14 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                 default:
                     break;
             }
-            context.setLineDash(_lineDash);
+            var dashArray = [];
+            for (var i = 0; i < _lineDash.length; i=i+2){
+                if(typeof _lineDash[i] === "number" && typeof _lineDash[i+1] === "number"){
+                    dashArray.push(_lineDash[i]);
+                    dashArray.push(_lineDash[i+1]);
+                }
+            }
+            context.setLineDash(dashArray);
 
             context.beginPath();
             var x1, x2, y1, y2;

--- a/src/idd/idd.ko.polyline.js
+++ b/src/idd/idd.ko.polyline.js
@@ -1,4 +1,3 @@
-
 (function (InteractiveDataDisplay) {
     if (!ko) {
         console.log("Knockout was no found, please load Knockout first");
@@ -61,6 +60,8 @@
                 data.fill68 = ko.unwrap(allBindings.get('iddFill68'));
             if (allBindings.has('iddFill95'))
                 data.fill95 = ko.unwrap(allBindings.get('iddFill95'));
+            if (allBindings.has('iddLineDash'))
+                data.lineDash = ko.unwrap(allBindings.get('iddLineDash'));
 
             var plotAttr = element.getAttribute("data-idd-plot");
             if (plotAttr != null) {
@@ -76,6 +77,6 @@
 
         InteractiveDataDisplay.KnockoutBindings.registerPlotBinding("polyline", updatePolyline, ['iddX', 'iddY', 'iddYMedian', 'iddLower68', 'iddUpper68', 'iddLower95',
             'iddUpeer95', 'iddFill68', 'iddFill95', 'iddStroke', 'iddThickness',
-            'iddLineCap', 'iddLineJoin'])
+            'iddLineCap', 'iddLineJoin', 'iddLineDash'])
     }
 })(InteractiveDataDisplay || (InteractiveDataDisplay = {}))


### PR DESCRIPTION
User can select fromthe set of predefined dash patterns: "dot", "dash", "dash dot", "long dash", "long dash dot", "long dash dot dot".
User can define dash pattern for polyline by the [ dash_length1, space1, dash_length2, space2, ... ] set. Knockout binding - iddLineDash.
Dashed plots are exportable to SVG.