### PR TITLE
Plot is ignored by fit-to-view along one of the axes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 1.5.36 (December 13, 2019)
+
+New features:
+ - added iddIgnoredByFitToViewX/iddIgnoredByFitToViewY knockout bindings so that a plot can be not respected by fit to view along one of the axes.
+
 ### 1.5.34 (July 30, 2019)
 
 Bugfix:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,7 @@
-### 1.5.36 (December 13, 2019)
+### 1.5.35 (December 13, 2019)
 
 New features:
  - added iddIgnoredByFitToViewX/iddIgnoredByFitToViewY knockout bindings so that a plot can be not respected by fit to view along one of the axes.
-
-### 1.5.35 (November 12, 2019)
-
-New features:
  - Added dash lines support. Choose from dash patterns: "dot", "dash", "dash dot", "long dash", "long dash dot", "long dash dot dot"; or define a set of number pairs: [ dash_length1, space1, dash_length2, space2, ... ]. Knockout binding - iddLineDash.
 
 ### 1.5.34 (July 30, 2019)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-data-display",
-  "version": "1.5.36",
+  "version": "1.5.35",
   "license": "Apache-2.0",
   "homepage": "https://github.com/predictionmachines/InteractiveDataDisplay/wiki",
   "description": "A JavaScript visualization library for dynamic data",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-data-display",
-  "version": "1.5.34",
+  "version": "1.5.36",
   "license": "Apache-2.0",
   "homepage": "https://github.com/predictionmachines/InteractiveDataDisplay/wiki",
   "description": "A JavaScript visualization library for dynamic data",

--- a/samples/KO.IgnoreFitToViewByAxis.html
+++ b/samples/KO.IgnoreFitToViewByAxis.html
@@ -17,10 +17,19 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.4.1/knockout-min.js"></script> 
     <script src="../dist/idd_knockout.js"></script>
 
-    <script type="text/javascript">		
+    <script type="text/javascript">
+        var vm = {
+            IsFirstLineIgnoredByFitToViewByX: ko.observable(false),
+            IsFirstLineIgnoredByFitToViewByY: ko.observable(false),
+            IsSecondLineIgnoredByFitToViewByX: ko.observable(false),
+            IsSecondLineIgnoredByFitToViewByY: ko.observable(false),
+            IsThirdLineIgnoredByFitToViewByX: ko.observable(false),
+            IsThirdLineIgnoredByFitToViewByY: ko.observable(false)
+        }
         $(document).ready(function () {
-            var chart = InteractiveDataDisplay.asPlot($("#chart"));
-            ko.applyBindings();
+            var chart1 = InteractiveDataDisplay.asPlot($("#chart"));
+            var chart2 = InteractiveDataDisplay.asPlot($("#chart2"));
+            ko.applyBindings(vm);
         });
     </script>
 </head>
@@ -64,6 +73,51 @@
             <p>IDD binding iddIgnoredByFitToViewX for the <font color="red">red line "Line 1"</font> is set to true. That's why one cannot see its leftmost part.</p>
             <p>IDD binding iddIgnoredByFitToViewY for the <font color="green">green line "Line 2"</font> is set to true. That's why one cannot see its upper part.</p>
             <p><font color="blue">Blue line "Line 3"</font> is fully respected by fit to view. That's why one can see the whole polyline.</p>
+        </div>
+    </div>
+    <div>
+        <div id="chart2" data-idd-plot="chart" style="width: 600px; height: 400px; float:left">
+            <div data-idd-plot="polyline"
+                data-idd-name="First Line"
+                id="Line21"
+                data-bind="
+                    iddX: [-10.0, 20.0, 30.0, 40.0, 50.0],
+                    iddY: [2.0, 15.0, 3.0, 15.0, 2.0],
+                    iddStroke: 'Red',
+                    iddThickness: 3,
+                    iddIgnoredByFitToViewX: IsFirstLineIgnoredByFitToViewByX,
+                    iddIgnoredByFitToViewY: IsFirstLineIgnoredByFitToViewByY
+                    ">				
+            </div>
+            <div data-idd-plot="polyline"
+                data-idd-name="Second line"
+                id="Line22"
+                data-bind="
+                    iddX: [2.0, 15.0, 3.0, 15.0, 2.0],
+                    iddY: [10.0, 20.0, 30.0, 40.0, 50.0],
+                    iddStroke: 'Green',
+                    iddThickness: 3,
+                    iddIgnoredByFitToViewX: IsSecondLineIgnoredByFitToViewByX,
+                    iddIgnoredByFitToViewY: IsSecondLineIgnoredByFitToViewByY
+                    ">				
+            </div>
+            <div data-idd-plot="polyline"
+                data-idd-name="Third line"
+                id="Line23"
+                data-bind="
+                    iddX: [50.0, 60.0, 70.0, 80.0, 90.0],
+                    iddY: [-10.0, 5.0, 0.0, 20.0, 10.0],
+                    iddStroke: 'Blue',
+                    iddThickness: 3,
+                    iddIgnoredByFitToViewX: IsThirdLineIgnoredByFitToViewByX,
+                    iddIgnoredByFitToViewY: IsThirdLineIgnoredByFitToViewByY
+                    ">				
+            </div>
+        </div>
+        <div style="display: inline-block; margin: 30px;">
+            <div><font color="red">First</font> polyline is ignored by fit-to-view by: X axis <input type="checkbox" data-bind="checked: IsFirstLineIgnoredByFitToViewByX"/>  Y axis <input type="checkbox" data-bind="checked: IsFirstLineIgnoredByFitToViewByY" /></div>
+            <div><font color="green">Second</font> polyline is ignored by fit-to-view by: X axis <input type="checkbox" data-bind="checked: IsSecondLineIgnoredByFitToViewByX"/>  Y axis <input type="checkbox" data-bind="checked: IsSecondLineIgnoredByFitToViewByY" /></div>
+            <div><font color="blue">Third</font> polyline is ignored by fit-to-view by: X axis <input type="checkbox" data-bind="checked: IsThirdLineIgnoredByFitToViewByX"/>  Y axis <input type="checkbox" data-bind="checked: IsThirdLineIgnoredByFitToViewByY" /></div>         
         </div>
     </div>
 </body>

--- a/samples/KO.IgnoreFitToViewByAxis.html
+++ b/samples/KO.IgnoreFitToViewByAxis.html
@@ -25,7 +25,7 @@
     </script>
 </head>
 <body>
-    <div style="display: inline-block">
+    <div>
         <div id="chart" data-idd-plot="chart" style="width: 600px; height: 400px; float:left">
             <div data-idd-plot="polyline"
                 data-idd-name="Line 1"
@@ -59,6 +59,11 @@
                     iddThickness: 2
                     ">				
             </div>
+        </div>
+        <div style="display: inline-block; margin: 30px;">
+            <p>IDD binding iddIgnoredByFitToViewX for the <font color="red">red line "Line 1"</font> is set to true. That's why one cannot see its leftmost part.</p>
+            <p>IDD binding iddIgnoredByFitToViewY for the <font color="green">green line "Line 2"</font> is set to true. That's why one cannot see its upper part.</p>
+            <p><font color="blue">Blue line "Line 3"</font> is fully respected by fit to view. That's why one can see the whole polyline.</p>
         </div>
     </div>
 </body>

--- a/samples/KO.IgnoreFitToViewByAxis.html
+++ b/samples/KO.IgnoreFitToViewByAxis.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10; IE=Edge" />
+    <title>Ignore fit to view by one of the axes</title>
+    <link rel="stylesheet" type="text/css" href="../dist/idd.css" />
+    <link rel="stylesheet" type="text/css" href="../src/css/IDDTheme.css" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/3.1.2/rx.lite.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.4.0/svg.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script> 
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.4.1/knockout-min.js"></script> 
+    <script src="../dist/idd_knockout.js"></script>
+
+    <script type="text/javascript">		
+        $(document).ready(function () {
+            var chart = InteractiveDataDisplay.asPlot($("#chart"));
+            ko.applyBindings();
+        });
+    </script>
+</head>
+<body>
+    <div style="display: inline-block">
+        <div id="chart" data-idd-plot="chart" style="width: 600px; height: 400px; float:left">
+            <div data-idd-plot="polyline"
+                data-idd-name="Line 1"
+                id="Line1"
+                data-bind="
+                    iddX: [-10.0, 20.0, 30.0, 40.0, 50.0],
+                    iddY: [2.0, 15.0, 3.0, 15.0, 2.0],
+                    iddStroke: 'Red',
+                    iddThickness: 3,
+                    iddIgnoredByFitToViewX: true
+                    ">				
+            </div>
+            <div data-idd-plot="polyline"
+                data-idd-name="Line 2"
+                id="Line2"
+                data-bind="
+                    iddX: [2.0, 15.0, 3.0, 15.0, 2.0],
+                    iddY: [10.0, 20.0, 30.0, 40.0, 50.0],
+                    iddStroke: 'Green',
+                    iddThickness: 3,
+                    iddIgnoredByFitToViewY: true
+                    ">				
+            </div>
+            <div data-idd-plot="polyline"
+                data-idd-name="Line 3"
+                id="Line3"
+                data-bind="
+                    iddX: [50.0, 60.0, 70.0, 80.0, 90.0],
+                    iddY: [-10.0, 5.0, 0.0, 20.0, 10.0],
+                    iddStroke: 'Blue',
+                    iddThickness: 2
+                    ">				
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/idd/idd.base.js
+++ b/src/idd/idd.base.js
@@ -261,6 +261,8 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
         var _isErrorVisible = false;
         var _aspectRatio; //actually scale ratio (xScale/yScale)
         var _isIgnoredByFitToView = false; //if true, the plot's bounding box is not respected during the common bounding box calculation
+        var _isIgnoredByFitToViewX = false; //if true, the plot's bounding box is not respected during the common bounding box calculation by X axis
+        var _isIgnoredByFitToViewY = false; //if true, the plot's bounding box is not respected during the common bounding box calculation by Y axis
         var _isAutoFitEnabled = true;
         var _requestFitToView = false;
         var _requestFitToViewX = false;
@@ -306,6 +308,12 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             }
             if(style.hasOwnProperty("ignored-by-fit-to-view")) {
                 _isIgnoredByFitToView = Boolean(style["ignored-by-fit-to-view"]);
+            }
+            if(style.hasOwnProperty("ignored-by-fit-to-view-x")) {
+                _isIgnoredByFitToViewX = Boolean(style["ignored-by-fit-to-view-x"]);
+            }
+            if(style.hasOwnProperty("ignored-by-fit-to-view-y")) {
+                _isIgnoredByFitToViewY = Boolean(style["ignored-by-fit-to-view-y"]);
             }
             _tooltipSettings = _tooltipSettings || {};
             if(style.hasOwnProperty("tooltipDelay")) {
@@ -372,6 +380,26 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             },
             set: function (value) {
                 _isIgnoredByFitToView = value;
+                if (_isAutoFitEnabled)
+                    this.requestUpdateLayout();
+            }
+        });
+        Object.defineProperty(this, "isIgnoredByFitToViewX", {
+            get: function () {
+                return _isIgnoredByFitToViewX;
+            },
+            set: function (value) {
+                _isIgnoredByFitToViewX = value;
+                if (_isAutoFitEnabled)
+                    this.requestUpdateLayout();
+            }
+        });
+        Object.defineProperty(this, "isIgnoredByFitToViewY", {
+            get: function () {
+                return _isIgnoredByFitToViewY;
+            },
+            set: function (value) {
+                _isIgnoredByFitToViewY = value;
                 if (_isAutoFitEnabled)
                     this.requestUpdateLayout();
             }
@@ -791,7 +819,21 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
                     if (plotBounds === undefined) {
                         undefinedBBPlots.push(plot);
                     } else {
-                        bounds = InteractiveDataDisplay.Utils.unionRects(bounds, plotBounds);
+                        var plotBoundsReplica = {
+                            x: plotBounds.x,
+                            y: plotBounds.y,
+                            width: plotBounds.width,
+                            height: plotBounds.height
+                        }
+                        if (plot.isIgnoredByFitToViewX) {
+                            plotBoundsReplica.x = NaN;
+                            plotBoundsReplica.width = NaN;
+                        }
+                        if (plot.isIgnoredByFitToViewY) {
+                            plotBoundsReplica.y = NaN;
+                            plotBoundsReplica.height = NaN;
+                        }
+                        bounds = InteractiveDataDisplay.Utils.unionRects(bounds, plotBoundsReplica);
                     }
                 }
             }
@@ -2552,7 +2594,6 @@ var _initializeInteractiveDataDisplay = function () { // determines settings dep
             var l95 = InteractiveDataDisplay.Utils.getBoundingBoxForArrays(_x, _y_l95, dataToPlotX, dataToPlotY);
 
             return InteractiveDataDisplay.Utils.unionRects(mean, InteractiveDataDisplay.Utils.unionRects(u68, InteractiveDataDisplay.Utils.unionRects(l68, InteractiveDataDisplay.Utils.unionRects(u95, l95))));
-
         };
 
         // Returns 4 margins in the screen coordinate system

--- a/src/idd/idd.figure.js
+++ b/src/idd/idd.figure.js
@@ -62,6 +62,7 @@ InteractiveDataDisplay.Figure = function (div, master) {
             var axis = InteractiveDataDisplay.InitializeAxis(jqdiv, params);
             jqdiv.axis = axis;
             jqdiv.dblclick(function () {
+                var placement = this.getAttribute("data-idd-placement"); // worked until Dec 2019 without this line
                 if (placement == "bottom" || placement == "top") that.master.fitToViewX();
                 else that.master.fitToViewY();
             });

--- a/src/idd/idd.ko.js
+++ b/src/idd/idd.ko.js
@@ -66,6 +66,46 @@
             }
         };
 
+        ko.bindingHandlers.iddIgnoredByFitToViewX = {
+            update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+                var value = valueAccessor();
+                var unwrappedName = ko.unwrap(value);
+
+                var plotAttr = element.getAttribute("data-idd-plot");
+                if(plotAttr != null) {
+                    if(typeof element.plot != 'undefined') {
+                        element.plot.isIgnoredByFitToViewX = unwrappedName;
+                    }
+                    else {
+                        //the case when the element was not yet initialized and not yet bound to the logical entity (plot)
+                        //storing the data in the DOM. it will be used by IDD during IDD-initializing of the dom element
+                        
+                        InteractiveDataDisplay.Utils.updateStyle(element, style, "ignored-by-fit-to-view-x", unwrappedName);
+                    }
+                }
+            }
+        };
+
+        ko.bindingHandlers.iddIgnoredByFitToViewY = {
+            update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+                var value = valueAccessor();
+                var unwrappedName = ko.unwrap(value);
+
+                var plotAttr = element.getAttribute("data-idd-plot");
+                if(plotAttr != null) {
+                    if(typeof element.plot != 'undefined') {
+                        element.plot.isIgnoredByFitToViewY = unwrappedName;
+                    }
+                    else {
+                        //the case when the element was not yet initialized and not yet bound to the logical entity (plot)
+                        //storing the data in the DOM. it will be used by IDD during IDD-initializing of the dom element
+                        
+                        InteractiveDataDisplay.Utils.updateStyle(element, style, "ignored-by-fit-to-view-y", unwrappedName);
+                    }
+                }
+            }
+        };
+
         ko.bindingHandlers.iddXlog = {
             update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var value = valueAccessor();

--- a/src/idd/idd.utils.js
+++ b/src/idd/idd.utils.js
@@ -136,11 +136,20 @@ InteractiveDataDisplay.Utils =
                 return rect2 === undefined ? undefined : { x: rect2.x, y: rect2.y, width: rect2.width, height: rect2.height };
             if (rect2 === undefined)
                 return rect1 === undefined ? undefined : { x: rect1.x, y: rect1.y, width: rect1.width, height: rect1.height };
+            
+            var minX = 0;
+            var maxX = 0;
+            if( isNaN(rect1.x) && isNaN(rect2.x) ) { minX = 0; maxX = 0; }
+            else if(isNaN(rect1.x)) { minX = rect2.x; maxX = rect2.x + rect2.width; }
+            else if(isNaN(rect2.x)) { minX = rect1.x; maxX = rect1.x + rect1.width; }
+            else { minX = Math.min(rect1.x, rect2.x); maxX = Math.max(rect1.x + rect1.width, rect2.x + rect2.width); }
 
-            var minX = Math.min(rect1.x, rect2.x);
-            var minY = Math.min(rect1.y, rect2.y);
-            var maxX = Math.max(rect1.x + rect1.width, rect2.x + rect2.width);
-            var maxY = Math.max(rect1.y + rect1.height, rect2.y + rect2.height);
+            var minY = 0;
+            var maxY = 0;
+            if( isNaN(rect1.y) && isNaN(rect2.y) ) { minY = 0; maxY = 0; }
+            else if(isNaN(rect1.y)) { minY = rect2.y; maxY = rect2.y + rect2.height; }
+            else if(isNaN(rect2.y)) { minY = rect1.y; maxY = rect1.y + rect1.height; }
+            else { minY = Math.min(rect1.y, rect2.y); maxY = Math.max(rect1.y + rect1.height, rect2.y + rect2.height); }
 
             return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
         },


### PR DESCRIPTION
Added iddIgnoredByFitToViewX/iddIgnoredByFitToViewY knockout bindings so that a plot can be not respected by fit to view along one of the axes.
Added a sample page KO.IgnoreFitToViewByAxis.html.